### PR TITLE
admin 사용자 존재하는지 확인하는 API 추가

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="FrameworkDetectionExcludesConfiguration">
-    <file type="web" url="file://$PROJECT_DIR$" />
-  </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_14" default="false" project-jdk-name="adopt-openjdk-11" project-jdk-type="JavaSDK" />
-</project>

--- a/src/main/java/com/lb/lightboard/bo/UserBO.java
+++ b/src/main/java/com/lb/lightboard/bo/UserBO.java
@@ -7,6 +7,8 @@
 package com.lb.lightboard.bo;
 
 import com.lb.lightboard.model.entity.User;
+import com.lb.lightboard.model.User;
+import com.lb.lightboard.model.type.UserStatusType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,5 +27,11 @@ public class UserBO {
 		List<User> users = userRepository.findByUserId(userId);
 		log.debug("users : {}", users);
 		return users.size() > 0;
+	}
+	
+	public boolean isExistAdminUser() {
+		List<User> adminUsers = userRepository.findByUserStatusType(UserStatusType.ADMIN);
+		log.debug("admin users : {}", adminUsers);
+		return !adminUsers.isEmpty();
 	}
 }

--- a/src/main/java/com/lb/lightboard/controller/UserController.java
+++ b/src/main/java/com/lb/lightboard/controller/UserController.java
@@ -25,4 +25,9 @@ public class UserController {
 	public boolean isDuplicateUserId(@RequestParam(value = "userId") String userId) {
 		return userBO.isDuplicateUserId(userId);
 	}
+	
+	@GetMapping(value = "/admin/check")
+	public boolean isExistAdminUser() {
+		return userBO.isExistAdminUser();
+	}
 }

--- a/src/main/java/com/lb/lightboard/model/entity/User.java
+++ b/src/main/java/com/lb/lightboard/model/entity/User.java
@@ -10,6 +10,7 @@ import javax.persistence.*;
 
 import com.lb.lightboard.model.type.UserAuthorityType;
 import com.lb.lightboard.model.type.UserStatusType;
+import com.lb.lightboard.model.type.converter.UserStatusTypeConverter;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -42,6 +43,7 @@ public class User {
 	long updatedUserNo;
 	@Column(name = "updated_detail")
 	String updatedDetail;
+	@Convert(converter = UserStatusTypeConverter.class)
 	@Column(name = "status")
 	UserStatusType userStatusType;
 	@Column(name = "reported_cnt")

--- a/src/main/java/com/lb/lightboard/model/type/UserStatusType.java
+++ b/src/main/java/com/lb/lightboard/model/type/UserStatusType.java
@@ -1,4 +1,22 @@
 package com.lb.lightboard.model.type;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum UserStatusType {
+	NORMAL("N"),
+	ADMIN("A");
+	
+	String dbCode;
+	
+	public static UserStatusType find(String dbCode) {
+		for (UserStatusType value : UserStatusType.values()) {
+			if (value.getDbCode().equals(dbCode)) {
+				return  value;
+			}
+		}
+		return null;
+	}
 }

--- a/src/main/java/com/lb/lightboard/model/type/converter/UserStatusTypeConverter.java
+++ b/src/main/java/com/lb/lightboard/model/type/converter/UserStatusTypeConverter.java
@@ -1,0 +1,20 @@
+package com.lb.lightboard.model.type.converter;
+
+import com.lb.lightboard.model.type.UserStatusType;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class UserStatusTypeConverter implements AttributeConverter<UserStatusType, String> {
+	
+	@Override
+	public String convertToDatabaseColumn(UserStatusType attribute) {
+		return attribute.getDbCode();
+	}
+	
+	@Override
+	public UserStatusType convertToEntityAttribute(String dbData) {
+		return UserStatusType.find(dbData);
+	}
+}

--- a/src/main/java/com/lb/lightboard/repository/UserRepository.java
+++ b/src/main/java/com/lb/lightboard/repository/UserRepository.java
@@ -6,6 +6,7 @@
  */
 package com.lb.lightboard.repository;
 
+import com.lb.lightboard.model.type.UserStatusType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,4 +17,5 @@ import java.util.List;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	List<User> findByUserId(String userId);
+	List<User> findByUserStatusType(UserStatusType userStatusType);
 }


### PR DESCRIPTION
## API Interface
```
GET /v1/api/user/admin/check
- param : 없음 
```

## 작업
- 어드민 사용자가 존재하는지 확인하는 API 추가
- `UserStatusType` Converter 구현

## 이슈
- 해당 api 요청 시, 기존에 존재하는 `v1/api/user={userId}` API가 같이 요청됨.. 수정 필요할 듯 