### PR TITLE
기존에 만든 API Header 적용

### DIFF
--- a/src/main/java/com/lb/lightboard/controller/UserController.java
+++ b/src/main/java/com/lb/lightboard/controller/UserController.java
@@ -7,9 +7,11 @@
 package com.lb.lightboard.controller;
 
 import com.lb.lightboard.model.entity.User;
+import com.lb.lightboard.model.network.status.ResponseStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import com.lb.lightboard.model.network.Header;
 
 import com.lb.lightboard.bo.UserBO;
 
@@ -20,13 +22,13 @@ public class UserController {
 	UserBO userBO;
 
 	@GetMapping(params = "userId")
-	public boolean isDuplicateUserId(@RequestParam(value = "userId") String userId) {
-		return userBO.isDuplicateUserId(userId);
+	public Header<Boolean> isDuplicateUserId(@RequestParam(value = "userId") String userId) {
+		return new Header<>(ResponseStatus.BOOLEAN_SUCCESS, userBO.isDuplicateUserId(userId));
 	}
 	
 	@GetMapping(value = "/admin/check")
-	public boolean isExistAdminUser() {
-		return userBO.isExistAdminUser();
+	public Header<Boolean> isExistAdminUser() {
+		return new Header<>(ResponseStatus.BOOLEAN_SUCCESS, userBO.isExistAdminUser());
 	}
 	
 	@PostMapping

--- a/src/main/java/com/lb/lightboard/model/network/Header.java
+++ b/src/main/java/com/lb/lightboard/model/network/Header.java
@@ -1,6 +1,7 @@
 package com.lb.lightboard.model.network;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.lb.lightboard.model.network.status.ResponseStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -29,7 +30,15 @@ public class Header<T> {
 
     // 계속 계속 바뀌는 data부분 -> 제네릭을 사용하자!
     private T data;
-
+    
+    // DATA INFO SETTING
+    public Header(ResponseStatus responseStatus, T data) {
+        this.transactionTime = LocalDateTime.now();
+        this.resultCode = responseStatus.getResult();
+        this.description = responseStatus.getDescription();
+        this.data = data;
+    }
+    
     // DATA OK
     public static <T> Header<T> OK() {
         return (Header<T>) Header.builder()

--- a/src/main/java/com/lb/lightboard/model/network/status/ResponseStatus.java
+++ b/src/main/java/com/lb/lightboard/model/network/status/ResponseStatus.java
@@ -1,0 +1,25 @@
+package com.lb.lightboard.model.network.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public enum ResponseStatus {
+	BOOLEAN_SUCCESS("200", "get boolean value");
+	
+	String result;
+	String description;
+	
+	@AllArgsConstructor
+	@Getter
+	public enum BoardFrame {
+		SUCCESS("200", "get one board-frame row finding by id");
+		
+		String result;
+		String description;
+	}
+}

--- a/src/test/java/com/lb/lightboard/controller/UserControllerTest.java
+++ b/src/test/java/com/lb/lightboard/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.lb.lightboard.controller;
 
+import com.lb.lightboard.model.network.Header;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,8 +11,8 @@ public class UserControllerTest extends BaseControllerTest {
 	
 	@Test
 	public void isDuplicatedUserId() {
-		boolean result = userController.isDuplicateUserId("12345");
+		Header<Boolean> result = userController.isDuplicateUserId("12345");
 		
-		Assertions.assertFalse(result);
+		Assertions.assertFalse(result.getData());
 	}
 }


### PR DESCRIPTION
## 작업
- Header 데이터를 Enum으로 관리하면 훨씬 깔끔할 것 같아서 Enum 선언
    - 차차, 다른 데이터들에 대해서도 해당 Enum에 추가하면 좋을듯
- 기존 API에 Header 적용 